### PR TITLE
advocate form

### DIFF
--- a/src/start/secure/advocate/report/index.html
+++ b/src/start/secure/advocate/report/index.html
@@ -27,17 +27,17 @@
         <form id="advocate-report" action="" method="post">
             <input type="hidden" name="advocate" id="advocate" value="">
             <label class="form-field" for="clients-choice">Who are you reporting on behalf of today?</label>
-            <p class="explainer">
+            <!--<p class="explainer">
                 Is the person that you are reporting on behalf missing from this list? <br>
                 <a id="full-org">👥 Check this list from your organization.</a><br>
-            </p>
+            </p>-->
             <select name="client" id="clients-choice">
             </select>
             <select name="org-client" id="org-clients">
             </select>
             <p class="explainer">
                 <span id="new-user">
-                    If you still do not see the person, fill out a <a id="new-user-form" href="https://weunlock.nyc"
+                    👥 If you still do not see the person, fill out a <a id="new-user-form" href="https://weunlock.nyc"
                         target="blank">new user enrollment</a> form first, and then return to <strong>refresh</strong>
                     this page.
                 </span>
@@ -218,7 +218,7 @@
 
             let userToken = JSON.parse(window.localStorage.getItem("gotrue.user")).token;
             let userInfo = JSON.parse(window.localStorage.getItem("gotrue.user"));
-            let newUserForm = "https://airtable.com/shrElSuAipPFb4fFZ?prefill_Organization%20choice=";
+            let newUserForm = "https://airtable.com/shrElSuAipPFb4fFZ?prefill_Organization%20Link=";
             // PROD REPORTS BASE, "User Information" table
 
             let advocateAssign = false;
@@ -295,7 +295,7 @@
 
             // prefill hidden advocate field & new user form
             $("input#advocate").val(advocate);
-            $("a#new-user-form").attr("href", `${newUserForm}${userInfo.app_metadata.org}&prefill_Advocate=${advocate}`);
+            $("a#new-user-form").attr("href", `${newUserForm}${userInfo.app_metadata.org}&prefill_Advocates=${advocate}`);
             // populate client dropdown options
             for (i = 0; i < clientList.length; i++) {
                 $('select#clients-choice').append($('<option>', {value: `${clientList[i].id}`, text: `${clientList[i].name}`}));


### PR DESCRIPTION
adjust form prefill for Org (no longer "Organization choice" but now "Organization Link" temporarily until we delete entirely to go via Advocate) - also hide "Full Client List" logic on front-end